### PR TITLE
chore: Test upgrading to Debian Sid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL       := /bin/bash
 .SHELLFLAGS += -e -u -o pipefail
 
 export REPOSITORY_ROOT := $(CURDIR)
-export IMAGE_NAME      ?= mailserver-testing:ci
+export IMAGE_NAME      ?= mailserver-sid-testing:ci
 export NAME            ?= $(IMAGE_NAME)
 
 MAKEFLAGS              += --no-print-directory

--- a/target/scripts/build/packages.sh
+++ b/target/scripts/build/packages.sh
@@ -79,7 +79,7 @@ function _install_packages() {
   local CODECS_PACKAGES=(
     altermime arj bzip2
     cabextract cpio file
-    gzip lhasa liblz4-tool
+    gzip lhasa lz4
     lrzip lzop nomarch
     p7zip-full pax rpm2cpio
     unrar-free unzip xz-utils
@@ -162,14 +162,16 @@ function _install_dovecot() {
 
 function _install_rspamd() {
   _log 'debug' 'Installing Rspamd'
-  _log 'trace' 'Adding Rspamd PPA'
-  curl -sSfL https://rspamd.com/apt-stable/gpg.key | gpg --dearmor >/etc/apt/trusted.gpg.d/rspamd.gpg
-  echo \
-    "deb [signed-by=/etc/apt/trusted.gpg.d/rspamd.gpg] http://rspamd.com/apt-stable/ ${VERSION_CODENAME} main" \
-    >/etc/apt/sources.list.d/rspamd.list
+  if [[ ${RSPAMD_COMMUNITY_REPO} -eq 1 ]]; then
+    _log 'trace' 'Adding Rspamd PPA'
+    curl -sSfL https://rspamd.com/apt-stable/gpg.key | gpg --dearmor >/etc/apt/trusted.gpg.d/rspamd.gpg
+    echo \
+      "deb [signed-by=/etc/apt/trusted.gpg.d/rspamd.gpg] http://rspamd.com/apt-stable/ ${VERSION_CODENAME} main" \
+      >/etc/apt/sources.list.d/rspamd.list
 
-  _log 'trace' 'Updating package index after adding PPAs'
-  apt-get "${QUIET}" update
+    _log 'trace' 'Updating package index after adding PPAs'
+    apt-get "${QUIET}" update
+  fi
 
   _log 'trace' 'Installing actual package'
   apt-get "${QUIET}" install rspamd redis-server


### PR DESCRIPTION
# Description

```
Nobody:
Me: Let's see what upgrades Debian Sid currently brings!
```

I don't recommend anyone using this. I might though as I run Sid in production in many places. But I do that having used Linux since the late 90s when you had to compile things into the kernel.  And having built linux from scratch MULTIPLE times.

When built, this is the difference from the stable build:

```
                 debian 12                    sid

amavisd-new   1:2.13.0-3+deb12u1            1:2.13.0-6
clamav        1.0.5+dfsg-1~deb12u1          1.3.1+dfsg-5
dovecot-core  1:2.3.19.1+dfsg1-2.1+deb12u1  1:2.3.21.1+dfsg1-1
fail2ban      1.1.0-1~upstream1             1.1.0-1~upstream1
fetchmail     6.4.37-1                      6.4.39-1
getmail6      6.18.11-2                     6.19.02-1
opendkim      2.11.0~beta2-8+deb12u1        2.11.0~beta2-9.1
opendmarc     1.4.2-2+b1                    1.4.2-5
openssl       3.0.14-1~deb12u2              3.3.2-1
postfix       3.7.11-0+deb12u1              3.9.0-3
postgrey      1.37-2                        1.37-2.1
pyzor         1:1.0.0-6                     1:1.0.0-7
razor         1:2.85-9                      1:2.85-9+b2
rspamd        3.9.1-1~82f43560f~bookworm    3.8.1-1.1
spamassassin  4.0.0-6                       4.0.1-2
```




